### PR TITLE
Add "C:/OSGeo4W64/apps/saga-ltr" to windows.default.paths and change file.exists to dir.exists

### DIFF
--- a/R/RSAGA-core.R
+++ b/R/RSAGA-core.R
@@ -134,7 +134,8 @@ rsaga.env = function(path = NULL, modules=NULL, workspace = ".",
       windows.defaults.paths <-
         c("C:/Progra~1/SAGA-GIS",
           "C:/SAGA-GIS",
-          "C:/OSGeo4W64/apps/saga")
+          "C:/OSGeo4W64/apps/saga",
+          "C:/OSGeo4W64/apps/saga-ltr")
       
       # Check if one path is valid
       for (pa in windows.defaults.paths) {

--- a/R/RSAGA-core.R
+++ b/R/RSAGA-core.R
@@ -191,7 +191,7 @@ rsaga.env = function(path = NULL, modules=NULL, workspace = ".",
   cmd = unname(cmd)
   
   # Check workspace
-  if (!file.exists(workspace)) {
+  if (!dir.exists(workspace)) {
     stop("Invalid workspace path ", workspace)
   }
   


### PR DESCRIPTION
Hey,

I changed the workspace check to dir.exists because dir.exists also yields TRUE if path string ends with a "/" e.g. dir.path("my_path/my_sub_patch/") is TRUE while file.path("my_path/my_sub_patch/") is FALSE even if the path exists. 

Cheers,
Fabian 
